### PR TITLE
Fix Spark URL

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -12,7 +12,7 @@ HADOOP_RES_DIR=/vagrant/resources/hadoop
 #spark
 SPARK_VERSION=spark-1.0.1
 SPARK_ARCHIVE=$SPARK_VERSION-bin-hadoop2.tgz
-SPARK_MIRROR_DOWNLOAD=http://www.google.com/url?q=http%3A%2F%2Fmirrors.ibiblio.org%2Fapache%2Fspark%2Fspark-1.0.1%2Fspark-1.0.1.tgz&sa=D&sntz=1&usg=AFQjCNHcDNB1l9iRsGJyQzF7g-wLC15_Ag
+SPARK_MIRROR_DOWNLOAD=http://archive.apache.org/dist/spark/spark-1.0.1/spark-1.0.1-bin-hadoop2.tgz
 SPARK_RES_DIR=/vagrant/resources/spark
 SPARK_CONF_DIR=/usr/local/spark/conf
 #ssh


### PR DESCRIPTION

This fixes #6 on `master` (I know other branches are switching to more recent Spark distribs).

